### PR TITLE
Member.color

### DIFF
--- a/lib/Member/color.js
+++ b/lib/Member/color.js
@@ -1,0 +1,11 @@
+module.exports = Eris => {
+    Object.defineProperty(Eris.Member.prototype, "color", {
+        get: function() {
+            const roles = this.roleObjects.filter(r => r.color !== 0);
+            if(roles.length == 0) return this.guild.roles.get(this.guild.id).color;
+            else return roles.reduce((prev, role) => !prev || role.higherThan(prev) ? role : prev).color;
+        }
+    });
+};
+
+module.exports.dep = ["Role.higherThan", "Member.roleObjects"];


### PR DESCRIPTION
Show a member's highest role's color - or the default @everyone color for the server.
This can be useful in embeds, when you want to make it dynamic to what the user's color shows.