### PR TITLE
Guild#findMembers and Member#effectiveName

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,14 @@ Example:
 ```js
 message.author.createMessage("Hello!");
 ```
+
+## Guild Additions 
+
+* findMembers(query) - get members based on the specified query.
+
+Returns: A collection of members that match the query based on their tag/discriminator/nickname/etc.
+
+Example:
+```js
+msg.guild.findMembers("2513");
+```

--- a/lib/Guild/findMembers.js
+++ b/lib/Guild/findMembers.js
@@ -1,0 +1,6 @@
+module.exports = Eris => {
+    Eris.Guild.prototype.findMembers = function(query) {
+        return this.members.filter(m => m.tag.toLowerCase().includes(query.toLowerCase()) || m.id === query.replace(/^<@!?(\d{16,20})>$/, '$1') ||
+            m.effectiveName.toLowerCase().includes(query.toLowerCase()));
+    };
+};

--- a/lib/Member/effectiveName.js
+++ b/lib/Member/effectiveName.js
@@ -1,0 +1,7 @@
+module.exports = Eris => {
+    Object.defineProperty(Eris.Member.prototype, "effectiveName", {
+        get: function() {
+            return this.nick || this.username;
+        }
+    });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eris-additions",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "extend prototypes for eris",
   "main": "index.js",
 	"engines": {


### PR DESCRIPTION
Guild#findMembers is a quick and easy way to grab a collection of all the members who match your search query, whether that be by mention, username, nickname, discriminator, their whole tag, or an exact ID.
Member#effectiveName is an easy way of grabbing a member's nickname or username, depending on whether they have a nickname set or not. Just makes it easier rather than having to type `member.nick || member.username` all the time.

Also, I did the `README.md` and `package.json` here so it's less work if/when merged 😉 