### PR TITLE
Member#effectiveName

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ Example:
 message.member.createMessage("hi");
 ```
 
+* effectiveName - the member's display name 
+
+Example:
+```js 
+message.channel.createMessage(`Your effective name is: ${mesage.member.effectiveName}`);
+```
+
 * hasPermission(permission) - if the member has a permission in the guild
 
 permission: string of Eris permission name

--- a/lib/Member/effectiveName.js
+++ b/lib/Member/effectiveName.js
@@ -1,0 +1,7 @@
+module.exports = Eris => {
+	Object.defineProperty(Eris.Member.prototype, 'effectiveName', {
+		get: function() {
+			return this.nick || this.username;
+		}
+	});
+};


### PR DESCRIPTION
Was originally combined with Guild#findMembers but that is now in a separate PR.
Member#effectiveName will return the member's display name, so pretty much their nickname if they have one set, or just their default username.

Updated README.md to go with it, I haven't bumped the version in case Guild#findMembers gets added as well.