### PR TITLE
Guild#findMembers

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,17 @@ Example:
 ```js
 message.author.createMessage("Hello!");
 ```
+
+## Guild Additions 
+
+* findMembers(query) - get a list of members who match the query
+
+query: a String that you wish to lookup against a guild's members.
+
+Returns: a Collection<Member> of members that match the query.
+
+Example:
+```js
+const members = message.guild.findMembers("Attribute");
+message.channel.createMessage(`There are ${members.length} members that match the query `Attribute`: ${members.map(m => m.effectiveName).join(", ")}`);
+```

--- a/lib/Guild/findMembers.js
+++ b/lib/Guild/findMembers.js
@@ -1,0 +1,6 @@
+module.exports = Eris => {
+    Eris.Guild.prototype.findMembers = function(query) {
+        return this.members.filter(m => m.tag.toLowerCase().includes(query.toLowerCase()) || m.id === query.replace(/^<@!?(\d{16,20})>$/, '$1') ||
+            m.effectiveName.toLowerCase().includes(query.toLowerCase()));
+    };
+};

--- a/lib/Guild/findMembers.js
+++ b/lib/Guild/findMembers.js
@@ -4,3 +4,5 @@ module.exports = Eris => {
             m.effectiveName.toLowerCase().includes(query.toLowerCase()));
     };
 };
+
+module.exports.deps = ["User.tag", "Member.effectiveName"];


### PR DESCRIPTION
Was combined with Member#effectiveName but separated into two PRs.
Guild#findMembers will look through all members in a guild and check whether they partially match the query in any way. This can be looking for discriminators, usernames, nicknames, general tags (username and discriminator put together), or you can lookup exact IDs.
For example, `message.guild.findMembers("Attribute")` would only return one member object in the Collection (hopefully) and that member would be myself.

Updated README.md for Guild#findMembers but haven't bumped the version in case Member#effectiveName gets accepted before this.