### PR TITLE
bump version to 1.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eris-additions",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "description": "extend prototypes for eris",
   "main": "index.js",
 	"engines": {


### PR DESCRIPTION
merged 2 new PRs and didn't update the version number so npm doesn't realise there's been an update...
bumped 2 minor version for 2 new features :)