### PR TITLE
Expose client.channel

### DIFF
--- a/lib/Channel/awaitMessages.js
+++ b/lib/Channel/awaitMessages.js
@@ -7,7 +7,7 @@ class MessageCollector extends EventEmitter {
 		this.options = options;
 		this.ended = false;
 		this.collected = [];
-		this.bot = channel.guild ? channel.guild.shard.client : channel._client;
+		this.bot = channel.guild ? channel.guild.shard.client : channel.client;
 
 		this.listener = message => this.verify(message);
 		this.bot.on("messageCreate", this.listener);

--- a/lib/Channel/createCode.js
+++ b/lib/Channel/createCode.js
@@ -1,6 +1,6 @@
 module.exports = Eris => {
 	Eris.Channel.prototype.createCode = function(code, lang) {
-		const client = this.guild ? this.guild.shard.client : this._client;
+		const client = this.guild ? this.guild.shard.client : this.client;
 		return client.createCode(this.id, code, lang);
 	};
 };

--- a/lib/Channel/createEmbed.js
+++ b/lib/Channel/createEmbed.js
@@ -1,6 +1,6 @@
 module.exports = Eris => {
 	Eris.Channel.prototype.createEmbed = function(embed) {
-		const client = this.guild ? this.guild.shard.client : this._client;
+		const client = this.guild ? this.guild.shard.client : this.client;
 		return client.createEmbed(this.id, embed);
 	};
 };


### PR DESCRIPTION
Recent Eris updates removed `channel._client` and officially exposed it under `channel.client`; this pull request reflects those changes, fixing issues like `awaitMessages` breaking in DMs after updating Eris.