### PR TITLE
Replacing "date" to "timestamp"

### DIFF
--- a/lib/Eris/Embed.js
+++ b/lib/Eris/Embed.js
@@ -52,7 +52,7 @@ class Embed {
 	}
 
 	timestamp(time = new Date()) {
-		this.date = time;
+		this.timestamp = time;
 
 		return this;
 	}


### PR DESCRIPTION
According to Discord, in order for there to be a timestamp in the embed, the property called "timestamp" must be put and not the one called "date".
You can still put a Date object and send it to Discord directly.

https://discord.com/developers/docs/resources/channel#embed-object