### PR TITLE
Adjust tag method to reflect username changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ Example:
 message.author.createMessage("Hello!");
 ```
 
+* tag - get the user's tag (`username#discriminator`)
+
+Returns: a string combining the user's username and discriminator. If they have migrated to the new username system, this will just be their username.
+
+Example:
+```js
+message.author.tag // attributeerror, or AttributeError#2513 on the legacy system
+```
+
 ## Guild Additions 
 
 * findMembers(query) - get a list of members who match the query

--- a/lib/User/tag.js
+++ b/lib/User/tag.js
@@ -1,7 +1,11 @@
 module.exports = (Eris) => {
     Object.defineProperty(Eris.User.prototype, "tag", {
         get: function() {
-            return `${this.username}#${this.discriminator}`;
+            return typeof this.username === "string"
+                ? this.discriminator === "0"
+                    ? this.username
+                    : `${this.username}#${this.discriminator}`
+                : null;
         }
     });
 };


### PR DESCRIPTION
Update the tag method to only return the user's username if they have migrated to the new username system. Otherwise, it'll continue to return their username & discrininator.

I've also updated the README with an example of how this property behaves.